### PR TITLE
Force synchronous AJAX calls on admin import

### DIFF
--- a/app/code/community/Metrilo/Analytics/Block/Head.php
+++ b/app/code/community/Metrilo/Analytics/Block/Head.php
@@ -18,7 +18,6 @@ class Metrilo_Analytics_Block_Head extends Mage_Core_Block_Template
      */
     public function getEvents()
     {
-        $helper = Mage::helper('metrilo_analytics');
         $events = (array)Mage::getSingleton('core/session')->getData(self::DATA_TAG);
         // clear events from session ater get events once
         Mage::getSingleton('core/session')->setData(self::DATA_TAG,'');

--- a/app/code/community/Metrilo/Analytics/Block/Head.php
+++ b/app/code/community/Metrilo/Analytics/Block/Head.php
@@ -37,7 +37,10 @@ class Metrilo_Analytics_Block_Head extends Mage_Core_Block_Template
         $request = Mage::app()->getRequest();
         $storeId = $helper->getStoreId($request);
 
-        if($helper->isEnabled($storeId))
+        if($helper->isEnabled($storeId)) {
             return $html;
+        }
+
+        return "";
     }
 }

--- a/app/code/community/Metrilo/Analytics/Helper/Asynchttpclient.php
+++ b/app/code/community/Metrilo/Analytics/Helper/Asynchttpclient.php
@@ -21,11 +21,11 @@ class Metrilo_Analytics_Helper_Asynchttpclient extends Mage_Core_Helper_Abstract
     }
 
     /**
-    * Create HTTP POSTasync request to URL
-    *
-    * @param String $url
-    * @param Array $bodyArray
-    * @return void
+     * Create HTTP POSTasync request to URL
+     * @param string $url
+     * @param $bodyArray
+     * @param bool $async
+     * @return void
     */
     public function post($url, $bodyArray = false, $async = true)
     {

--- a/app/code/community/Metrilo/Analytics/Helper/Asynchttpclient.php
+++ b/app/code/community/Metrilo/Analytics/Helper/Asynchttpclient.php
@@ -12,20 +12,12 @@ class Metrilo_Analytics_Helper_Asynchttpclient extends Mage_Core_Helper_Abstract
     * @param String $url
     * @return void
     */
-    public function get($url)
+    public function get($url, $async = true)
     {
         $parsedUrl = parse_url($url);
         $raw = $this->_buildRawGet($parsedUrl['host'], $parsedUrl['path']);
 
-        $fp = fsockopen(
-            $parsedUrl['host'],
-            isset($parsedUrl['port']) ? $parsedUrl['port'] : 80,
-            $errno, $errstr, 30);
-
-        if ($fp) {
-            fwrite($fp, $raw);
-            fclose($fp);
-        }
+        $this->_executeRequest($parsedUrl, $raw, $async)
     }
 
     /**
@@ -35,28 +27,14 @@ class Metrilo_Analytics_Helper_Asynchttpclient extends Mage_Core_Helper_Abstract
     * @param Array $bodyArray
     * @return void
     */
-    public function post($url, $bodyArray = false)
+    public function post($url, $bodyArray = false, $async = true)
     {
         $parsedUrl = parse_url($url);
         $encodedBody = $bodyArray ? json_encode($bodyArray) : '';
 
         $raw = $this->_buildRawPost($parsedUrl['host'], $parsedUrl['path'], $encodedBody);
 
-        $fp = fsockopen(
-            $parsedUrl['host'],
-            isset($parsedUrl['port']) ? $parsedUrl['port'] : 80,
-            $errno, $errstr, 30);
-
-        if ($fp) {
-            fwrite($fp, $raw);
-
-            // Read the response so that the socket does not override the next batch
-            while (!feof($fp)) {
-                $response = fgets($fp, 1024);
-            }
-            
-            fclose($fp);
-        }
+        $this->_executeRequest($parsedUrl, $raw, $async)
     }
 
     private function _buildRawGet($host, $path)
@@ -82,5 +60,28 @@ class Metrilo_Analytics_Helper_Asynchttpclient extends Mage_Core_Helper_Abstract
         $out .= $encodedCall;
 
         return $out;
+    }
+
+    private function _executeRequest($parsedUrl, $raw, $async = true)
+    {
+        $fp = fsockopen($parsedUrl['host'],
+                        isset($parsedUrl['port']) ? $parsedUrl['port'] : 80,
+                        $errno, $errstr, 30);
+
+        if ($fp) {
+            fwrite($fp, $raw);
+
+            if (!$async) {
+                $this->_waitForResponse($fp);
+            }
+
+            fclose($fp);
+        }
+    }
+
+    private function _waitForResponse($fp) {
+        while (!feof($fp)) {
+            fgets($fp, 1024);
+        }
     }
 }

--- a/app/code/community/Metrilo/Analytics/Helper/Asynchttpclient.php
+++ b/app/code/community/Metrilo/Analytics/Helper/Asynchttpclient.php
@@ -17,7 +17,7 @@ class Metrilo_Analytics_Helper_Asynchttpclient extends Mage_Core_Helper_Abstract
         $parsedUrl = parse_url($url);
         $raw = $this->_buildRawGet($parsedUrl['host'], $parsedUrl['path']);
 
-        $this->_executeRequest($parsedUrl, $raw, $async)
+        $this->_executeRequest($parsedUrl, $raw, $async);
     }
 
     /**
@@ -34,7 +34,7 @@ class Metrilo_Analytics_Helper_Asynchttpclient extends Mage_Core_Helper_Abstract
 
         $raw = $this->_buildRawPost($parsedUrl['host'], $parsedUrl['path'], $encodedBody);
 
-        $this->_executeRequest($parsedUrl, $raw, $async)
+        $this->_executeRequest($parsedUrl, $raw, $async);
     }
 
     private function _buildRawGet($host, $path)

--- a/app/code/community/Metrilo/Analytics/Helper/Data.php
+++ b/app/code/community/Metrilo/Analytics/Helper/Data.php
@@ -163,20 +163,20 @@ class Metrilo_Analytics_Helper_Data extends Mage_Core_Helper_Abstract
      * @param Array(Mage_Sales_Model_Order) $orders
      * @return void
      */
-    public function callBatchApi($storeId, $orders)
+    public function callBatchApi($storeId, $orders, $async = true)
     {
         try {
             $ordersForSubmition = $this->_buildOrdersForSubmition($orders);
             $call = $this->_buildCall($storeId, $ordersForSubmition);
 
-            $this->_callMetriloApiAsync($storeId, $call);
+            $this->_callMetriloApi($storeId, $call, $async);
         } catch (Exception $e) {
             Mage::log($e->getMessage(), null, 'Metrilo_Analytics.log');
         }
     }
 
     // Private functions start here
-    private function _callMetriloApiAsync($storeId, $call) {
+    private function _callMetriloApi($storeId, $call, $async = true) {
         ksort($call);
 
         $basedCall = base64_encode(Mage::helper('core')->jsonEncode($call));

--- a/app/code/community/Metrilo/Analytics/controllers/Adminhtml/AjaxController.php
+++ b/app/code/community/Metrilo/Analytics/controllers/Adminhtml/AjaxController.php
@@ -22,8 +22,8 @@ class Metrilo_Analytics_Adminhtml_AjaxController extends Mage_Adminhtml_Controll
             $chunkId = (int)$this->getRequest()->getParam('chunk_id');
             // Get orders from the Database
             $orders = $import->getOrders($storeId, $chunkId);
-            // Send orders via API helper method
-            $helper->callBatchApi($storeId, $orders);
+            // Send orders via API helper method (last parameter shows synchronity)
+            $helper->callBatchApi($storeId, $orders, false);
             $result['success'] = true;
         } catch (Exception $e) {
             Mage::logException($e);


### PR DESCRIPTION
Change the Asynchttpclient so it can do synchronous requests. Those are needed when doing big admin imports.