### PR TITLE
prepareOrderDetails()  - fix for item price

### DIFF
--- a/app/code/community/Metrilo/Analytics/Helper/Data.php
+++ b/app/code/community/Metrilo/Analytics/Helper/Data.php
@@ -129,11 +129,12 @@ class Metrilo_Analytics_Helper_Data extends Mage_Core_Helper_Abstract
             if (in_array($item->getSku(), $skusAdded)) continue;
 
             $skusAdded[] = $item->getSku();
+			$itemPrice = (float)($item->getPrice()) ? $item->getPrice() : $item->getProduct()->getFinalPrice();
             $dataItem = array(
-                'id'        => $item->getProductId(),
-                'price'     => (float)$item->getPrice() ? $item->getPrice() : $item->getProduct()->getFinalPrice(),
-                'name'      => $item->getName(),
-                'url'       => $item->getProduct()->getProductUrl(),
+                'id'        => (string)$item->getProductId(),
+                'price'     => (float)$itemPrice,
+                'name'      => (string)$item->getName(),
+                'url'       => (string)$item->getProduct()->getProductUrl(),
                 'quantity'  => (int)$item->getQtyOrdered()
             );
             if ($item->getProductType() == 'configurable' || $item->getProductType() == 'grouped') {


### PR DESCRIPTION
Price of order item and option_price is now being sent as float to Metrilo
example:
"items" => [
                [0] {
                              "id" => "418",
                           "price" => 1234.5,
                            "name" => "Tori Tank",
                             "url" => "tori-tank-595.html",
                        "quantity" => 1,
                       "option_id" => "wbk003xl",
                     "option_name" => "Tori Tank",
                    "option_price" => 1234.5
                }