### PR TITLE
Version 1.3.3

### DIFF
--- a/app/code/community/Metrilo/Analytics/etc/config.xml
+++ b/app/code/community/Metrilo/Analytics/etc/config.xml
@@ -8,7 +8,7 @@
 <config>
     <modules>
         <Metrilo_Analytics>
-            <version>1.3.2</version>
+            <version>1.3.3</version>
         </Metrilo_Analytics>
     </modules>
     <frontend>


### PR DESCRIPTION
New module version that is excluding orders without email from sync with Metrilo.