### PR TITLE
KYP-1199: Create custom event and tag for newsletter subscribers on Magento 1

### DIFF
--- a/app/code/community/Metrilo/Analytics/Helper/Events/CustomEvent.php
+++ b/app/code/community/Metrilo/Analytics/Helper/Events/CustomEvent.php
@@ -1,0 +1,17 @@
+<?php
+class Metrilo_Analytics_Helper_Events_CustomEvent extends Mage_Core_Helper_Abstract
+{
+    private $customEvent;
+    
+    public function __construct
+    (
+        $customEvent
+    ) {
+        $this->customEvent = $customEvent;
+    }
+    
+    public function callJS()
+    {
+        return 'window.metrilo.customEvent("' . $this->customEvent . '");';
+    }
+}

--- a/app/code/community/Metrilo/Analytics/Model/CustomerObserver.php
+++ b/app/code/community/Metrilo/Analytics/Model/CustomerObserver.php
@@ -7,6 +7,7 @@ class Metrilo_Analytics_Model_CustomerObserver extends Varien_Event_Observer
     private $_customerModel;
     private $_subscriberModel;
     private $_customerGroupModel;
+    private $_sessionEvents;
     
     public function _construct()
     {
@@ -15,6 +16,7 @@ class Metrilo_Analytics_Model_CustomerObserver extends Varien_Event_Observer
         $this->_customerModel      = Mage::getModel('customer/customer');
         $this->_subscriberModel    = Mage::getModel('newsletter/subscriber');
         $this->_customerGroupModel = Mage::getModel('customer/group');
+        $this->_sessionEvents      = Mage::helper('metrilo_analytics/sessionEvents');
     }
     
     public function customerUpdate($observer)
@@ -62,6 +64,12 @@ class Metrilo_Analytics_Model_CustomerObserver extends Varien_Event_Observer
                     return $this->metriloCustomer($this->_customerModel->load($customerId));
                 } else {
                     $subscriberEmail = $subscriber->getEmail();
+                    $identifyCustomer = new Metrilo_Analytics_Helper_Events_IdentifyCustomer($subscriberEmail);
+                    $customEvent      = new Metrilo_Analytics_Helper_Events_CustomEvent('Subscribed');
+    
+                    $this->sessionEvents->addSessionEvent($identifyCustomer->callJs());
+                    $this->sessionEvents->addSessionEvent($customEvent->callJs());
+                    
                     return new Metrilo_Analytics_Helper_MetriloCustomer(
                         $subscriber->getStoreId(),
                         $subscriberEmail,
@@ -69,7 +77,7 @@ class Metrilo_Analytics_Model_CustomerObserver extends Varien_Event_Observer
                         $subscriberEmail,
                         $subscriberEmail,
                         true,
-                        ['guest_customer']
+                        ['Newsletter']
                     );
                 }
                 

--- a/app/code/community/Metrilo/Analytics/Model/CustomerObserver.php
+++ b/app/code/community/Metrilo/Analytics/Model/CustomerObserver.php
@@ -67,8 +67,8 @@ class Metrilo_Analytics_Model_CustomerObserver extends Varien_Event_Observer
                     $identifyCustomer = new Metrilo_Analytics_Helper_Events_IdentifyCustomer($subscriberEmail);
                     $customEvent      = new Metrilo_Analytics_Helper_Events_CustomEvent('Subscribed');
     
-                    $this->sessionEvents->addSessionEvent($identifyCustomer->callJs());
-                    $this->sessionEvents->addSessionEvent($customEvent->callJs());
+                    $this->_sessionEvents->addSessionEvent($identifyCustomer->callJs());
+                    $this->_sessionEvents->addSessionEvent($customEvent->callJs());
                     
                     return new Metrilo_Analytics_Helper_MetriloCustomer(
                         $subscriber->getStoreId(),


### PR DESCRIPTION

===

Jira story [#KYP-1199](https://metrilojira.atlassian.net/browse/KYP-1199) in project *Know Your Power*:

> Currently, there is no specific event or tag coming for the newsletter subscribers from Magento 2 store.
> 
> We need that in order to trigger automated emails and filer customers in the Customer Database.
> 
> The event should be “subscribed”
> 
> The tag should be “newsletter”