### PR TITLE
KYP-1444: Remove names generation from the magento newsletter form

### DIFF
--- a/app/code/community/Metrilo/Analytics/Model/CustomerObserver.php
+++ b/app/code/community/Metrilo/Analytics/Model/CustomerObserver.php
@@ -74,8 +74,8 @@ class Metrilo_Analytics_Model_CustomerObserver extends Varien_Event_Observer
                         $subscriber->getStoreId(),
                         $subscriberEmail,
                         strtotime($subscriber->getData('change_status_at')) * 1000,
-                        $subscriberEmail,
-                        $subscriberEmail,
+                        '',
+                        '',
                         true,
                         ['Newsletter']
                     );

--- a/app/code/community/Metrilo/Analytics/Model/CustomerObserver.php
+++ b/app/code/community/Metrilo/Analytics/Model/CustomerObserver.php
@@ -73,7 +73,7 @@ class Metrilo_Analytics_Model_CustomerObserver extends Varien_Event_Observer
                     return new Metrilo_Analytics_Helper_MetriloCustomer(
                         $subscriber->getStoreId(),
                         $subscriberEmail,
-                        strtotime($subscriber->getData('change_status_at')) * 1000,
+                        time() * 1000,
                         '',
                         '',
                         true,


### PR DESCRIPTION
Removing email assigned to first/last name for default newsletter customer event.